### PR TITLE
player: fix OnTagEnter the first time it is played

### DIFF
--- a/player.go
+++ b/player.go
@@ -100,7 +100,7 @@ func (p *Player) Play(tagName string) error {
 		return nil
 	}
 
-	if p.CurrentTag != nil {
+	if p.CurrentTag == nil {
 		p.PrevFrameIndex = -1
 	} else {
 		p.PrevFrameIndex = p.FrameIndex


### PR DESCRIPTION
The first time it is played the previous frame must be set to -1 so it detects there is a new tag playing. It did not work when the tag started in frame 0 as the previous frame was also 0.